### PR TITLE
Fix mysqli error handler variable

### DIFF
--- a/project_get_latest_role.php
+++ b/project_get_latest_role.php
@@ -22,5 +22,5 @@
 	    echo $json;
 	} else {
 	    // Handle the case where the query fails
-	    echo "Error executing query: " . mysqli_error($link);
+            echo "Error executing query: " . mysqli_error($db);
 	}

--- a/project_get_latest_tech.php
+++ b/project_get_latest_tech.php
@@ -23,5 +23,5 @@
 	    echo $json;
 	} else {
 	    // Handle the case where the query fails
-	    echo "Error executing query: " . mysqli_error($link);
+            echo "Error executing query: " . mysqli_error($db);
 	}

--- a/project_get_list_assigned_roles.php
+++ b/project_get_list_assigned_roles.php
@@ -22,5 +22,5 @@
 	    echo $json;
 	} else {
 	    // Handle the case where the query fails
-	    echo "Error executing query: " . mysqli_error($link);
+            echo "Error executing query: " . mysqli_error($db);
 	}

--- a/project_get_list_assigned_techs.php
+++ b/project_get_list_assigned_techs.php
@@ -23,5 +23,5 @@
 	    echo $json;
 	} else {
 	    // Handle the case where the query fails
-	    echo "Error executing query: " . mysqli_error($link);
+            echo "Error executing query: " . mysqli_error($db);
 	}


### PR DESCRIPTION
## Summary
- ensure database errors use `$db` handle in project-related scripts

## Testing
- `php -l project_get_latest_role.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68506f41c3048321874cd0006a8bd3ae