### PR TITLE
Fix header user comment

### DIFF
--- a/include/header.php
+++ b/include/header.php
@@ -28,7 +28,7 @@ if (!isset($_SESSION['user_id'])) {
               echo "<a href='project_inbox.php?user_id=1' class='small-blue-badge'>$msg_count</a>";
               ?>
     			<div id="clock"></div>
-		</div><!--logger_user -->
+                </div><!-- logged_user -->
 </div><!-- header -->
 
 <script type="text/javascript">


### PR DESCRIPTION
## Summary
- fix the logged_user comment typo in `include/header.php`

## Testing
- `php -l include/header.php` *(fails: php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68506f42e5cc8321a6430592a1d3844c