### PR TITLE
Add PHPUnit tests and ProjectDuration rowData option

### DIFF
--- a/tests/ProjectDurationTest.php
+++ b/tests/ProjectDurationTest.php
@@ -1,0 +1,29 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class ProjectDurationTest extends TestCase
+{
+    public function testFinishedProjectShowsDays()
+    {
+        $row = [
+            'project_status'   => 'finished',
+            'established_date' => '2024-01-01 00:00:00',
+            'finished_date'    => '2024-01-10 00:00:00'
+        ];
+
+        $result = ProjectDuration(1, $row);
+        $this->assertMatchesRegularExpression('/\d+\s+day/', $result);
+    }
+
+    public function testIncompleteProjectReturnsDuration()
+    {
+        $row = [
+            'project_status'   => 'active',
+            'established_date' => date('Y-m-d H:i:s', strtotime('-1 day')),
+            'finished_date'    => null
+        ];
+
+        $result = ProjectDuration(1, $row);
+        $this->assertNotEmpty($result);
+    }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,13 @@
+# Test Suite
+
+This project uses [PHPUnit](https://phpunit.de/) for its automated tests. All test files live in this `tests` directory.
+
+## Running the tests
+
+From the repository root run:
+
+```bash
+phpunit -c tests/phpunit.xml
+```
+
+The command expects `phpunit` to be available in your `PATH`. If you do not have it installed, download the PHPUnit PHAR release and invoke it with `php phpunit.phar`.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+// Add test directory to include path so functions.php picks up our dbconnect stub
+set_include_path(__DIR__ . PATH_SEPARATOR . get_include_path());
+require_once __DIR__ . '/../include/functions.php';

--- a/tests/dbconnect.php
+++ b/tests/dbconnect.php
@@ -1,0 +1,4 @@
+<?php
+// SQLite stub connection for tests
+$db = null;
+?>

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Miniwrike Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
## Summary
- enable injecting data into `ProjectDuration` to ease testing
- add a `tests` suite with PHPUnit configuration
- cover `ProjectDuration` behaviour with new PHPUnit tests
- document how to run the tests

## Testing
- `phpunit -c tests/phpunit.xml` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68506f449b148321905be9358430c9f9