### PR TITLE
Fix typos in bug and idea alerts

### DIFF
--- a/miniwrike_bug_save.php
+++ b/miniwrike_bug_save.php
@@ -11,6 +11,6 @@
             $save_bug = "INSERT INTO bugs (bug_title, bug_text, is_fixed, added_date) VALUES ('$bug_title','$bug_text',$is_fixed,now())";
             $result=mysqli_query($db, $save_bug) or die(mysqli_error($db))  ;
         
-        echo "<script>alert('Minecraft IS: Bol vtytvoreny nova bug');
+        echo "<script>alert('Minecraft IS: Bol vytvoreny nova bug');
         window.location.href='miniwrike_bugs.php';
         </script>";

--- a/miniwrike_idea_save.php
+++ b/miniwrike_idea_save.php
@@ -11,6 +11,6 @@
             $save_idea = "INSERT INTO ideas (idea_title, idea_text, is_applied, added_date) VALUES ('$idea_title','$idea_text', $is_applied,now())";
             $result=mysqli_query($db, $save_idea);
         
-        echo "<script>alert('Minecraft IS: Bola vtytvorena nova idea');
+        echo "<script>alert('Minecraft IS: Bola vytvorena nova idea');
         window.location.href='miniwrike_ideas.php';
         </script>";


### PR DESCRIPTION
## Summary
- fix Slovak typos in alert messages for bug and idea creation

## Testing
- `php -l miniwrike_bug_save.php` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68506f3dceac8321a6e119c815ba5b95